### PR TITLE
FWF-553 Adjusting CSS to make Assignee tick mark prominent

### DIFF
--- a/camunda-formio-tasklist-vue/src/components/TaskList.vue
+++ b/camunda-formio-tasklist-vue/src/components/TaskList.vue
@@ -142,10 +142,10 @@
                     <div class='cft-assignee-change-box row'>
                       <v-select @search="fetchOptions" :options="autoUserList" v-model="userSelected" class="col-9 col-md-9"/>
                       <span @click="onSetassignee" class="col-9 col-md-1">
-                        <i class="bi bi-check"></i>
+                        <i class="bi bi-check assignee-tickmark-icon"></i>
                       </span>
                       <span @click="toggleassignee" class="col-9 col-md-1">
-                        <i class="fa fa-times ml-1"></i>
+                        <i class="fa fa-times ml-1 assignee-cancel-icon"></i>
                       </span>
                     </div>
                   </div>

--- a/camunda-formio-tasklist-vue/src/styles/camundaFormIOTasklist.scss
+++ b/camunda-formio-tasklist-vue/src/styles/camundaFormIOTasklist.scss
@@ -434,4 +434,10 @@ li {
   background-color: #1a5a96;
   color: white;
 }
+.assignee-tickmark-icon {
+  font-size: 1.6em;
+}
+.assignee-cancel-icon {
+  font-size: 1.4em;
+}
 }


### PR DESCRIPTION
**JIRA**: FWF-553

**Changes**
- Adjust font size of assignee tick mark to make it more prominent
- Adjust font size of cancel icon to align correctly with the tick mark.

**Note**
The entire row misaligns in a smaller window due to a mix of CSS styles overlapping with one another. That'll be corrected in another ticket.

**Screenshot**
![image](https://user-images.githubusercontent.com/84348052/120000129-573c6c80-bf87-11eb-909e-8c6ab581e04b.png)
