### PR TITLE
[vue][service-flow-#886 ]  task sort order added

### DIFF
--- a/camunda-formio-tasklist-vue/docs/components/TaskList.md
+++ b/camunda-formio-tasklist-vue/docs/components/TaskList.md
@@ -18,6 +18,7 @@ solution in your Vue.js based project.
 | formsflowaiUrl :triangular_flag_on_post: | string | undefined | The URL endpoint which you would like to host your Vue based application.|
 | containerHeight | string | 100vh | Prop to adjust the height values of Vue component, in case of Vue component is too much for your integrated application. You can adjust the height from the range 100-400 |
 | taskSortBy | string | "created" | Prop to decide by default what value should the tasks be sorted when displayed at first. You can use the values like - "created", "dueDate", "followUpDate", "priority", "name", "assignee" |
+| taskSortOrder  | string | "desc" | Prop to decide by default what value should the tasks should be ordered when displayed at first. You can use the values like - "desc", "asc" |
 
 🚩- mandatory props to be passed
 
@@ -27,15 +28,16 @@ solution in your Vue.js based project.
 import CamundaTasklist from "camunda-formio-tasklist-vue/src/components/TaskList.vue";
 
 <CamundaTasklist
-  :bpmApiUrl="https://somewebsite.com/camunda/engine-rest"
-  :token="eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJrYTFKalB6Vy1EaHNFSE9vd2NZVHRJdW9sR3FqT0NhN1NYV0RFc"
-  :formIOApiUrl="https://random.com/api"
-  :formIOResourceId="3242affds123adfa"
-  :formIOReviewerId="123adsf123dafd1a"
-  :formIOReviewer="reviewer"
-  :formsflowaiUrl="https://yourwebsite.com"
-  :formsflowaiApiUrl="https://yourwebsite.com/api"
-  :formIOUserRoles="["forms-flow"]"
-  :taskSortBy="priority"
+  bpmApiUrl="https://somewebsite.com/camunda/engine-rest"
+  token="eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJrYTFKalB6Vy1EaHNFSE9vd2NZVHRJdW9sR3FqT0NhN1NYV0RFc"
+  formIOApiUrl="https://random.com/api"
+  formIOResourceId="3242affds123adfa"
+  formIOReviewerId="123adsf123dafd1a"
+  formIOReviewer="reviewer"
+  formsflowaiUrl="https://yourwebsite.com"
+  formsflowaiApiUrl="https://yourwebsite.com/api"
+  formIOUserRoles="["forms-flow"]"
+  taskSortBy="priority"
+  taskSortOrder="asc"
 />
 ```

--- a/camunda-formio-tasklist-vue/src/components/TaskList.vue
+++ b/camunda-formio-tasklist-vue/src/components/TaskList.vue
@@ -9,6 +9,7 @@
       :selectedfilterId="selectedfilterId"
       :payload="payload"
       :taskSortBy="taskSortBy"
+      :taskSortOrder="taskSortOrder"
     />
     <b-row class="cft-service-task-list mt-1">
       <b-col
@@ -412,7 +413,10 @@ export default class Tasklist extends Mixins(TaskListMixin) {
   @Prop({
     default: "created"
   }) public taskSortBy!: string
-
+  @Prop({
+    default: "desc"
+  }) public taskSortOrder!: string
+  
   @StoreServiceFlowModule.Getter("getFormsFlowTaskCurrentPage")
   private getFormsFlowTaskCurrentPage: any;
   @StoreServiceFlowModule.Getter("getFormsFlowTaskId")

--- a/camunda-formio-tasklist-vue/src/components/layout/Header.vue
+++ b/camunda-formio-tasklist-vue/src/components/layout/Header.vue
@@ -26,6 +26,7 @@
         :perPage="perPage"
         :payload="payload"
         :taskSortBy="taskSortBy"
+        :taskSortOrder="taskSortOrder"
         />
       </div>
     </div>
@@ -60,6 +61,7 @@ export default class Header extends Mixins(BaseMixin) {
   @Prop() private selectedfilterId!: string;
   @Prop() private payload!: Payload;
   @Prop() private taskSortBy!: string
+  @Prop() private taskSortOrder!: string
 
   @serviceFlowModule.Getter("getFormsFlowTaskCurrentPage")
   private getFormsFlowTaskCurrentPage: any;

--- a/camunda-formio-tasklist-vue/src/components/sort/TaskListSort.vue
+++ b/camunda-formio-tasklist-vue/src/components/sort/TaskListSort.vue
@@ -66,6 +66,7 @@ import {
   TASK_SORT_DEFAULT_PARAM_NAME,
   TASK_SORT_DEFAULT_PRIORITY,
   TaskListSortType,
+  SORT_ORDER
 } from "../../models";
 import {
   Payload 
@@ -89,6 +90,7 @@ export default class TaskListSort extends Vue {
   @Prop() private selectedfilterId!: string;
   @Prop() private payload!: Payload;
   @Prop() private taskSortBy!: string
+  @Prop() private taskSortOrder!: string
 
   @serviceFlowModule.Getter("getFormsFlowTaskCurrentPage")
   private getFormsFlowTaskCurrentPage: any;
@@ -194,25 +196,61 @@ export default class TaskListSort extends Vue {
     });
   }
   getTaskSortOption () {
+    /**
+   * "created" is the default TaskSortBy and "desc" is the deafult TaskSortOrder
+   */
+    const sortOptionsDetails = {
+    } as TaskListSortType;
     if (TASK_SORT_DEFAULT_DUE_DATE.sortBy === this.taskSortBy){
-      this.payload.sorting = [TASK_SORT_DEFAULT_DUE_DATE];
+      sortOptionsDetails.sortBy = TASK_SORT_DEFAULT_DUE_DATE.sortBy;
+      sortOptionsDetails.label = TASK_SORT_DEFAULT_DUE_DATE.label;
+      sortOptionsDetails.sortOrder = TASK_SORT_DEFAULT_DUE_DATE.sortOrder;
+      if (this.taskSortOrder === SORT_ORDER.ASCENDING){
+        sortOptionsDetails.sortOrder = SORT_ORDER.ASCENDING;
+      }
     }
     else if (TASK_SORT_DEFAULT_FOLLOW_UP_DATE.sortBy === this.taskSortBy){
-      this.payload.sorting = [TASK_SORT_DEFAULT_FOLLOW_UP_DATE];
+      sortOptionsDetails.sortBy = TASK_SORT_DEFAULT_FOLLOW_UP_DATE.sortBy;
+      sortOptionsDetails.label = TASK_SORT_DEFAULT_FOLLOW_UP_DATE.label;
+      sortOptionsDetails.sortOrder = TASK_SORT_DEFAULT_FOLLOW_UP_DATE.sortOrder;
+      if (this.taskSortOrder === SORT_ORDER.ASCENDING){
+        sortOptionsDetails.sortOrder = SORT_ORDER.ASCENDING;
+      }
     }
     else if (TASK_SORT_DEFAULT_PARAM_NAME.sortBy === this.taskSortBy){
-      this.payload.sorting = [TASK_SORT_DEFAULT_PARAM_NAME];
+      sortOptionsDetails.sortBy = TASK_SORT_DEFAULT_PARAM_NAME.sortBy;
+      sortOptionsDetails.label = TASK_SORT_DEFAULT_PARAM_NAME.label;
+      sortOptionsDetails.sortOrder = TASK_SORT_DEFAULT_PARAM_NAME.sortOrder;
+      if (this.taskSortOrder === SORT_ORDER.ASCENDING){
+        sortOptionsDetails.sortOrder = SORT_ORDER.ASCENDING;
+      }
     }
     else if (TASK_SORT_DEFAULT_ASSINGEE.sortBy === this.taskSortBy){
-      this.payload.sorting = [TASK_SORT_DEFAULT_ASSINGEE];
+      sortOptionsDetails.sortBy = TASK_SORT_DEFAULT_ASSINGEE.sortBy;
+      sortOptionsDetails.label = TASK_SORT_DEFAULT_ASSINGEE.label;
+      sortOptionsDetails.sortOrder = TASK_SORT_DEFAULT_ASSINGEE.sortOrder;
+      if (this.taskSortOrder === SORT_ORDER.ASCENDING){
+        sortOptionsDetails.sortOrder = SORT_ORDER.ASCENDING;
+      }
     }
     else if (TASK_SORT_DEFAULT_PRIORITY.sortBy === this.taskSortBy){
-      this.payload.sorting = [TASK_SORT_DEFAULT_PRIORITY];
+      sortOptionsDetails.sortBy = TASK_SORT_DEFAULT_PRIORITY.sortBy;
+      sortOptionsDetails.label = TASK_SORT_DEFAULT_PRIORITY.label;
+      sortOptionsDetails.sortOrder = TASK_SORT_DEFAULT_PRIORITY.sortOrder;
+      if (this.taskSortOrder === SORT_ORDER.ASCENDING){
+        sortOptionsDetails.sortOrder = SORT_ORDER.ASCENDING;
+      }
     } else 
     {
-      // created is the default task sort
-      this.payload.sorting = [TASK_FILTER_LIST_DEFAULT_PARAM_CREATED];
+      // created is the default task sort by
+      sortOptionsDetails.sortBy = TASK_FILTER_LIST_DEFAULT_PARAM_CREATED.sortBy;
+      sortOptionsDetails.label = TASK_FILTER_LIST_DEFAULT_PARAM_CREATED.label;
+      sortOptionsDetails.sortOrder = TASK_FILTER_LIST_DEFAULT_PARAM_CREATED.sortOrder;
+      if (this.taskSortOrder === SORT_ORDER.ASCENDING){
+        sortOptionsDetails.sortOrder = SORT_ORDER.ASCENDING;
+      }
     }
+    this.payload.sorting = [sortOptionsDetails];
     this.sortList = this.payload.sorting;
   }
   mounted () {

--- a/camunda-formio-tasklist-vue/src/models/sortOptions.ts
+++ b/camunda-formio-tasklist-vue/src/models/sortOptions.ts
@@ -38,3 +38,8 @@ export const TASK_SORT_DEFAULT_PRIORITY: TaskListSortType = {
   sortOrder: "desc",
   label: "Priority"
 };
+
+export enum SORT_ORDER {
+  ASCENDING = "asc",
+  DESCENDING = "desc"
+}


### PR DESCRIPTION
# Issue Tracking

JIRA: 
https://aottech.atlassian.net/secure/RapidBoard.jspa?rapidView=18&projectKey=FWF&modal=detail&selectedIssue=FWF-886&assignee=606de33996e8d60068d2118a

# Changes
Now, clients have the option to set default sort order passing `taskSortOrder` Props. If nothing is passed 'desc' is the default task sort order.
![image](https://user-images.githubusercontent.com/77353155/134204069-9751733b-5029-4bbf-8de9-18c7c6d9baca.png)

** _taskSortOrder_ options**
` ASCENDING = "asc",
  DESCENDING = "desc" `