### PR TITLE
Camunda base url change to support BPM Abstraction

### DIFF
--- a/rpa-robocorp-extension/external-client-extension/src/main/resources/application.yaml
+++ b/rpa-robocorp-extension/external-client-extension/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ robot:
 
 
 client:
-  base-url: ${CAMUNDA_BPM_URL}/camunda/engine-rest # the URL pointing to the Camunda Platform Runtime REST API
+  base-url: ${CAMUNDA_BPM_URL}/camunda/engine-rest-ext # the URL pointing to the Camunda Platform Runtime REST API
   lock-duration: ${LOCK_DURATION:3000} # defines how many milliseconds the External Tasks are locked until they can be fetched again
   max-tasks: ${MAX_TASKS:10}
   disable-backoff-strategy: true


### PR DESCRIPTION
* Camunda base url change `/camunda/engine-rest-ext`